### PR TITLE
Load nested Typesafe configs more correctly.

### DIFF
--- a/typesafe/src/main/scala/knobs/Typesafe.scala
+++ b/typesafe/src/main/scala/knobs/Typesafe.scala
@@ -17,32 +17,66 @@
 package knobs
 import com.typesafe.config.{Config => TC, _}
 import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
 import scalaz.concurrent.Task
 
 object Typesafe {
   def config: Task[Config] = Task {
-    val cfg = ConfigFactory.load
-    def go(o: ConfigObject): Env =
-      o.foldLeft(Config.empty.env) {
-        case (m, (k, v)) => v.valueType match {
-          case ConfigValueType.OBJECT => go(cfg.getObject(k))
-          case ConfigValueType.NULL => m
+    def convertList(list: ConfigList): CfgList = {
+      def unwrap[T](c: ConfigValue)(implicit ev: ClassTag[T]): T =
+        c.unwrapped match {
+          case t: T => t
           case _ =>
-            def convert(v: ConfigValue): CfgValue = v.valueType match {
-              case ConfigValueType.BOOLEAN =>
-                CfgBool(cfg.getBoolean(k))
-              case ConfigValueType.LIST =>
-                CfgList(cfg.getList(k).toList.map(convert))
-              case ConfigValueType.NUMBER =>
-                CfgNumber(cfg.getDouble(k))
-              case ConfigValueType.STRING =>
-                CfgText(cfg.getString(k))
-              case x => sys.error(s"Can't convert $v to a CfgValue")
-            }
-            m + (k -> convert(v))
+            sys.error(s"Can't convert $c to underlying type ${ev.runtimeClass.getName}")
+        }
+
+      val items: List[CfgValue] =
+        list.toList.flatMap { v =>
+          v.valueType match {
+            case ConfigValueType.NULL => None
+            case ConfigValueType.BOOLEAN =>
+              Some(CfgBool(unwrap[Boolean](v)))
+            case ConfigValueType.LIST =>
+              Some(convertList(unwrap[ConfigList](v)))
+            case ConfigValueType.NUMBER =>
+              Some(CfgNumber(unwrap[Number](v).doubleValue))
+            case ConfigValueType.STRING =>
+              Some(CfgText(unwrap[String](v)))
+            case x =>
+              sys.error(s"Can't convert $v to a CfgValue")
+          }
+        }
+
+      CfgList(items)
+    }
+
+    def convertTypesafeConfig(cfg: TC) = {
+      cfg.entrySet.foldLeft(Config.empty.env) {
+        case (m, entry) => {
+          val (k, v) = (entry.getKey, entry.getValue)
+          v.valueType match {
+            case ConfigValueType.OBJECT => m
+            case ConfigValueType.NULL => m
+            case _ =>
+              def convert(v: ConfigValue): CfgValue = v.valueType match {
+                case ConfigValueType.BOOLEAN =>
+                  CfgBool(cfg.getBoolean(k))
+                case ConfigValueType.LIST =>
+                  convertList(cfg.getList(k))
+                case ConfigValueType.NUMBER =>
+                  CfgNumber(cfg.getNumber(k).doubleValue)
+                case ConfigValueType.STRING =>
+                  CfgText(cfg.getString(k))
+                case x => sys.error(s"Can't convert $v to a CfgValue")
+              }
+              m + (k -> convert(v))
+          }
         }
       }
-    Config(go(cfg.root))
+    }
+
+    val cfg = ConfigFactory.load
+    Config(convertTypesafeConfig(cfg))
   }
 }
 


### PR DESCRIPTION
When using the ConfigObject interface of Typesafe Config, the
key provided during traversal is a relative path, not the
path from the root. Also, you cannot use the full path to
refer to particular items within a list.

Instead here, the code uses a traversal of the Config using
entrySet, and then a more specialised conversion between the
list types.