### PR TITLE
Fixed several things with regard to file watchers

### DIFF
--- a/core/src/main/scala/knobs/Resource.scala
+++ b/core/src/main/scala/knobs/Resource.scala
@@ -218,7 +218,7 @@ object Resource {
     def watch(path: Worth[File]) = for {
       ds <- load(path)
       rs <- recursiveImports(path.worth, ds)
-      es <- Task.fork((path.worth +: rs).traverse(f => watchEvent(f.toPath)))
+      es <- (path.worth +: rs).traverse(f => watchEvent(f.toPath))
     } yield (ds, mergeN(Process.emitAll(es.map(_.map(_ => ())))))
   }
 

--- a/core/src/main/scala/knobs/package.scala
+++ b/core/src/main/scala/knobs/package.scala
@@ -70,7 +70,10 @@ package object knobs {
    * `"$(HOME)/myapp.cfg"`.
    */
   def loadImmutable(files: List[KnobsResource]): Task[Config] =
-    load(files).flatMap(_.immutable)
+    load(files.map(_.map {
+      case WatchBox(b, w) => ResourceBox(b)(w)
+      case x => x
+    })).flatMap(_.immutable)
 
   /**
    * Create a `MutableConfig` from the contents of the named files, placing them


### PR DESCRIPTION
* Made watching optional
* Turned off all watching for `ImmutableConfig`, since it doesn't support reloading anyway.
* Fixed an issue where loading a file had a side effect to create the file watcher.
* Now creating one `WatchService` per file, since our stream is calling `take`, which would manifest itself as missed updates if more than one file was being watched.
