### PR TITLE
Upgrade to Scalaz-Stream 0.8a/Scalaz 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
   - 2.10.5
-  - 2.11.6
+  - 2.11.8
 jdk:
   - oraclejdk8
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -7,6 +7,6 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalaz.stream" %% "scalaz-stream" % "0.7.3a",
-  "oncue.ermine"      %% "ermine-parser" % "0.2.1-2"
+  "org.scalaz.stream" %% "scalaz-stream" % "0.8.1a",
+  "oncue.ermine"      %% "ermine-parser" % "0.3"
 )

--- a/core/src/main/scala/knobs/package.scala
+++ b/core/src/main/scala/knobs/package.scala
@@ -111,7 +111,7 @@ package object knobs {
         s <- IORef(Map[Pattern, List[ChangeHandler]]())
         bc = BaseConfig(paths = p, cfgMap = m, subs = s)
         ticks = mergeN(Process.emitAll(loaded.values.map(_._2).toSeq))
-        _ <- Task(ticks.evalMap(_ => bc.reload).run.runAsync(_.fold(_ => (), _ => ())))(pool)
+        _ <- Task(ticks.evalMap(_ => bc.reload).run.unsafePerformAsync(_.fold(_ => (), _ => ())))(pool)
       } yield bc
 
   private [knobs] def addDot(p: String): String =

--- a/core/src/test/scala/knobs/FileWatcherTest.scala
+++ b/core/src/test/scala/knobs/FileWatcherTest.scala
@@ -47,6 +47,6 @@ object FileWatcherTests extends Properties("FileWatch") {
       _   <- Task.delay(latch.await)
       r   <- ref.read
     } yield r == "\"bar\""
-    prg.run
+    prg.unsafePerformSync
   }
 }

--- a/core/src/test/scala/knobs/Test.scala
+++ b/core/src/test/scala/knobs/Test.scala
@@ -104,21 +104,21 @@ object Test extends Properties("Knobs") {
       case _ => false
     }
 
-  property("load-pathological-config") = loadTest.run
+  property("load-pathological-config") = loadTest.unsafePerformSync
 
-  property("interpolation") = interpTest.run
+  property("interpolation") = interpTest.unsafePerformSync
 
-  property("import") = importTest.run
+  property("import") = importTest.unsafePerformSync
 
-  property("load-system-properties") = loadPropertiesTest.run
+  property("load-system-properties") = loadPropertiesTest.unsafePerformSync
 
-  property("load-fallback-chain") = fallbackTest.run
+  property("load-fallback-chain") = fallbackTest.unsafePerformSync
 
-  property("fallback-chain-errors") = fallbackErrorTest.run
+  property("fallback-chain-errors") = fallbackErrorTest.unsafePerformSync
 
-  property("load-uri") = uriTest.run
+  property("load-uri") = uriTest.unsafePerformSync
 
-  property("classloader") = classLoaderTest.run
+  property("classloader") = classLoaderTest.unsafePerformSync
 
 
 }

--- a/project.sbt
+++ b/project.sbt
@@ -1,9 +1,9 @@
 
 organization in Global := "oncue.knobs"
 
-scalaVersion in Global := "2.10.5"
+scalaVersion in Global := "2.11.8"
 
-crossScalaVersions in Global := Seq("2.11.6", "2.10.5")
+crossScalaVersions in Global := Seq("2.11.8", "2.10.5")
 
 scalacOptions in Global := Seq(
   "-deprecation",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.3.5-SNAPSHOT"
+version in ThisBuild := "4.0.0-SNAPSHOT"

--- a/zookeeper/src/main/scala/knobs/Zookeeper.scala
+++ b/zookeeper/src/main/scala/knobs/Zookeeper.scala
@@ -176,7 +176,7 @@ object ZooKeeper {
   def unsafeFromResource(customConfig: List[KnobsResource]): (ResourceBox, Task[Unit]) = unsafe(customConfig)
 
   protected def unsafe(config: List[KnobsResource] = defaultCfg): (ResourceBox, Task[Unit]) = {
-    val (box, c) = doZK(config).run
+    val (box, c) = doZK(config).unsafePerformSync
     (box, Task.delay(c.close))
   }
 

--- a/zookeeper/src/test/scala/knobs/ZookeeperTest.scala
+++ b/zookeeper/src/test/scala/knobs/ZookeeperTest.scala
@@ -41,7 +41,7 @@ object ZooKeeperTests extends Properties("ZooKeeper") {
     c.start
     c.create.forPath("/knobs.cfg", "foo = 10\n".toArray.map(_.toByte))
     val n = load(List(ZNode(c, "/knobs.cfg").required)).flatMap(cfg =>
-      cfg.require[Int]("foo")).run
+      cfg.require[Int]("foo")).unsafePerformSync
     c.close
     server.close
     n == 10
@@ -70,7 +70,7 @@ object ZooKeeperTests extends Properties("ZooKeeper") {
       }
       n2 <- ref.read
     } yield n1 == 10 && n2 == 20
-    val r = prg.run
+    val r = prg.unsafePerformSync
     c.close
     server.close
     r


### PR DESCRIPTION
- Upgrade to `ermine-parser` 0.3 (recompiled against scalaz 7.2)
- Fix deprecation warnings. Rename `run*` -> `unsafePerform*`

NOTE: https://github.com/oncue/ermine-parser/pull/1 must be merged and deployed first