### PR TITLE
Turn off `sbt-release#releaseCrossBuild`

### DIFF
--- a/project/common.scala
+++ b/project/common.scala
@@ -47,7 +47,7 @@ object common {
     else ver.copy(qualifier = ver.qualifier.map(_.replaceAll("-SNAPSHOT", "")))
 
   def releaseSettings = Seq(
-    releaseCrossBuild := true,
+    releaseCrossBuild := false,
     releaseVersion := { ver =>
       sys.env.get("TRAVIS_BUILD_NUMBER").orElse(sys.env.get("BUILD_NUMBER"))
         .map(s => try Option(s.toInt) catch { case _: NumberFormatException => Option.empty[Int] })

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.6.0-SNAPSHOT"
+version in ThisBuild := "3.6.1-SNAPSHOT"


### PR DESCRIPTION
as we're already using Travis' matrix