### PR TITLE
update usage with resolver for scalaz-stream dependency

### DIFF
--- a/docs/src/main/tut/usage.md
+++ b/docs/src/main/tut/usage.md
@@ -24,6 +24,12 @@ You will probably need to add a resolver entry so SBT can find the jar:
 
 Once you have the dependency added to your project and SBT `update` has downloaded the JAR, you're ready to start adding configuration knobs to your project!
 
+If you get an unresolved `scalaz-stream` dependency, you will need to also add the following resolver to SBT:
+
+````
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+````
+
 <a name="resources"></a>
 
 # Configuration Resources


### PR DESCRIPTION
When trying to use Knobs as per the documentation, I got the following
scalaz-stream dependency resolution error:

[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scalaz.stream#scalaz-stream_2.11;0.7.1a: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn]  Note: Unresolved dependencies path:
[warn]      org.scalaz.stream:scalaz-stream_2.11:0.7.1a
[warn]        +- oncue.knobs:core_2.11:3.3.3

Adding in the scalaz bintray resolver to the SBT project, fixes
the issue. Updated the usage doco with this fix.